### PR TITLE
feat: generic GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           commands: |
             oc whoami
-            echo "commands=whoami-output-ok" >> "$GITHUB_OUTPUT"
+            echo "whoami-output-ok" >> "$GITHUB_OUTPUT"
           oc_namespace: ${{ vars.oc_namespace }}
           oc_server: ${{ vars.oc_server }}
           oc_token: ${{ secrets.oc_token }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -18,7 +18,9 @@ jobs:
       - id: whoami
         uses: ./
         with:
-          commands: oc whoami
+          commands: |
+            oc whoami
+            echo "commands=whoami-output-ok" >> "$GITHUB_OUTPUT"
           oc_namespace: ${{ vars.oc_namespace }}
           oc_server: ${{ vars.oc_server }}
           oc_token: ${{ secrets.oc_token }}
@@ -32,6 +34,10 @@ jobs:
           echo "Outputs: ${{ toJSON(steps.whoami.outputs) }}"
           if [ "${{ steps.whoami.outputs.triggered }}" != "true" ]; then
             echo "Error!  Verify outputs."
+            exit 1
+          fi
+          if [ "${{ steps.whoami.outputs.commands }}" != "whoami-output-ok" ]; then
+            echo "Error! Generic commands output did not match expected value."
             exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ This action returns:
 - `triggered`: boolean (`'true'` or `'false'`) indicating whether trigger paths changed
 - `commands`: generic command output channel from the `commands` step (usually empty unless explicitly set)
 
-`commands` is expected to be empty in most runs. To populate it, write a `commands=<value>` entry to `$GITHUB_OUTPUT` inside your `commands` input.
+`commands` is expected to be empty in most runs. To populate it, write to `$GITHUB_OUTPUT` inside your `commands` input. Plain text lines are automatically mapped to the `commands` output (you do not need to prefix with `commands=`).
 
 ```yaml
 jobs:
@@ -144,7 +144,7 @@ jobs:
           oc_token: ${{ secrets.OC_TOKEN }}
           commands: |
             oc whoami
-            echo "commands=$(oc whoami)" >> "$GITHUB_OUTPUT"
+            echo "$(oc whoami)" >> "$GITHUB_OUTPUT"
 
   result:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -121,26 +121,38 @@ cronjob:
 
 # Output
 
-The action will return a boolean (true|false) of whether a this action's triggers have fired. It can be useful for follow-up tasks, like running tests or cronjobs.
+This action returns:
+
+- `triggered`: boolean (`'true'` or `'false'`) indicating whether trigger paths changed
+- `commands`: generic command output from the `commands` step
+
+To populate `commands`, write a `commands=<value>` entry to `$GITHUB_OUTPUT` inside your `commands` input.
 
 ```yaml
 jobs:
   command:
     runs-on: ubuntu-latest
     outputs:
-      triggered: ${{ steps.meaningful_step_name.outputs.triggered }}
+      triggered: ${{ steps.oc.outputs.triggered }}
+      commands: ${{ steps.oc.outputs.commands }}
     steps:
-      - id: meaningful_step_name
+      - id: oc
         uses: bcgov/action-oc-runner@vX.Y.Z
-   ...
+        with:
+          oc_namespace: ${{ vars.oc_namespace }}
+          oc_server: ${{ vars.oc_server }}
+          oc_token: ${{ secrets.OC_TOKEN }}
+          commands: |
+            oc whoami
+            echo "commands=$(oc whoami)" >> "$GITHUB_OUTPUT"
 
   result:
     runs-on: ubuntu-latest
     needs: [command]
     steps:
-      - needs: [command]
-        run: |
-          echo "Triggered = ${{ needs.command.outputs.triggered }}
+      - run: |
+          echo "Triggered = ${{ needs.command.outputs.triggered }}"
+          echo "Command output = ${{ needs.command.outputs.commands }}"
 ```
 
 # Feedback

--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ cronjob:
 This action returns:
 
 - `triggered`: boolean (`'true'` or `'false'`) indicating whether trigger paths changed
-- `commands`: generic command output from the `commands` step
+- `commands`: generic command output channel from the `commands` step (usually empty unless explicitly set)
 
-To populate `commands`, write a `commands=<value>` entry to `$GITHUB_OUTPUT` inside your `commands` input.
+`commands` is expected to be empty in most runs. To populate it, write a `commands=<value>` entry to `$GITHUB_OUTPUT` inside your `commands` input.
 
 ```yaml
 jobs:

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ This action returns:
 - `triggered`: boolean (`'true'` or `'false'`) indicating whether trigger paths changed
 - `commands`: generic command output channel from the `commands` step (usually empty unless explicitly set)
 
-`commands` is expected to be empty in most runs. To populate it, write to `$GITHUB_OUTPUT` inside your `commands` input. Plain text lines are automatically mapped to the `commands` output (you do not need to prefix with `commands=`).
+`commands` is expected to be empty in most runs. To populate it, write to `$GITHUB_OUTPUT` inside your `commands` input. Plain text lines are automatically mapped to the `commands` output (you do not need to prefix with `commands=`). Existing `commands=<value>` usage is still supported.
 
 ```yaml
 jobs:

--- a/action.yml
+++ b/action.yml
@@ -80,6 +80,9 @@ inputs:
     pattern: "^[0-9]+[mhs]$"
 
 outputs:
+  commands:
+    description: Generic output for commands run, useful for debugging
+    value: ${{ steps.commands.outputs.commands }}
   job-name:
     description: Name of the job created from the cronjob param
     value: ${{ steps.cronjob.outputs.job-name }}
@@ -155,6 +158,7 @@ runs:
         ref: ${{ inputs.ref }}
 
     - if: steps.diff.outputs.triggered == 'true' && inputs.commands
+      id: commands
       shell: bash
       run: |
         # Run command(s)

--- a/action.yml
+++ b/action.yml
@@ -164,8 +164,26 @@ runs:
       id: commands
       shell: bash
       run: |
+        REAL_GITHUB_OUTPUT="$GITHUB_OUTPUT"
+        ACTION_OUTPUT_FILE="$(mktemp)"
+        export GITHUB_OUTPUT="$ACTION_OUTPUT_FILE"
+
         # Run command(s)
         ${{ inputs.commands }}
+
+        # Map user-written output lines to the action's generic commands output.
+        # Allows plain `echo "value" >> "$GITHUB_OUTPUT"` without requiring `commands=`.
+        if [ -s "$ACTION_OUTPUT_FILE" ]; then
+          {
+            echo "commands<<EOF_ACTION_OC_RUNNER_COMMANDS"
+            if grep -q '^commands=' "$ACTION_OUTPUT_FILE"; then
+              sed -n 's/^commands=//p' "$ACTION_OUTPUT_FILE"
+            else
+              cat "$ACTION_OUTPUT_FILE"
+            fi
+            echo "EOF_ACTION_OC_RUNNER_COMMANDS"
+          } >> "$REAL_GITHUB_OUTPUT"
+        fi
 
     - if: steps.diff.outputs.triggered == 'true' && inputs.commands && inputs.cronjob
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -81,7 +81,10 @@ inputs:
 
 outputs:
   commands:
-    description: Generic output for commands run, useful for debugging
+    description: |
+      Generic output channel for data produced by the commands step.
+      Typically populated via $GITHUB_OUTPUT in the commands step and may be empty
+      if no commands are run or the commands step does not execute.
     value: ${{ steps.commands.outputs.commands }}
   job-name:
     description: Name of the job created from the cronjob param

--- a/action.yml
+++ b/action.yml
@@ -167,6 +167,7 @@ runs:
         REAL_GITHUB_OUTPUT="$GITHUB_OUTPUT"
         ACTION_OUTPUT_FILE="$(mktemp)"
         export GITHUB_OUTPUT="$ACTION_OUTPUT_FILE"
+        trap 'rm -f "$ACTION_OUTPUT_FILE"' EXIT
 
         # Run command(s)
         ${{ inputs.commands }}
@@ -174,14 +175,31 @@ runs:
         # Map user-written output lines to the action's generic commands output.
         # Allows plain `echo "value" >> "$GITHUB_OUTPUT"` without requiring `commands=`.
         if [ -s "$ACTION_OUTPUT_FILE" ]; then
+          DELIM="EOF_ACTION_OC_RUNNER_COMMANDS_$(uuidgen 2>/dev/null || cat /proc/sys/kernel/random/uuid 2>/dev/null || echo "${RANDOM}${RANDOM}$$")"
           {
-            echo "commands<<EOF_ACTION_OC_RUNNER_COMMANDS"
+            echo "commands<<$DELIM"
             if grep -q '^commands=' "$ACTION_OUTPUT_FILE"; then
               sed -n 's/^commands=//p' "$ACTION_OUTPUT_FILE"
+            elif grep -q '^commands<<' "$ACTION_OUTPUT_FILE"; then
+              awk '
+                /^commands<</ {
+                  split($0, a, "<<")
+                  tag = a[2]
+                  in_block = 1
+                  next
+                }
+                in_block && $0 == tag {
+                  in_block = 0
+                  exit
+                }
+                in_block {
+                  print
+                }
+              ' "$ACTION_OUTPUT_FILE"
             else
               cat "$ACTION_OUTPUT_FILE"
             fi
-            echo "EOF_ACTION_OC_RUNNER_COMMANDS"
+            echo "$DELIM"
           } >> "$REAL_GITHUB_OUTPUT"
         fi
 


### PR DESCRIPTION
## Summary

Improves the generic `commands` action output so callers can write plain lines to `$GITHUB_OUTPUT` in `inputs.commands` without requiring a `commands=` prefix.

## What Changed

- Added top-level action output `commands` in `action.yml`:
  - `outputs.commands.value: ${{ steps.commands.outputs.commands }}`
- Added `id: commands` to the commands execution step so step outputs are addressable
- Updated command-step output handling to:
  - temporarily capture command-step writes to `$GITHUB_OUTPUT`
  - map captured content to the action output key `commands` automatically
  - preserve backward compatibility with existing `commands=<value>` lines
- Updated README output docs to describe plain output usage and compatibility
- Added/updated PR workflow test to verify plain output mapping:
  - `echo "whoami-output-ok" >> "$GITHUB_OUTPUT"`
  - assert `steps.whoami.outputs.commands == "whoami-output-ok"`

## Why

Users requested a simpler consumption pattern so they can append to `$GITHUB_OUTPUT` directly without remembering the `commands=` key format.

## Validation

- Verified updated files are syntactically valid in repo context
- Confirmed composite-action output wiring (`id` + `steps.<id>.outputs.<name>`)
- Confirmed workflow test covers plain output mapping path

## Example

Within `commands` input:

```bash
oc whoami
echo "$(oc whoami)" >> "$GITHUB_OUTPUT"
```

Downstream job output:

```yaml
${{ needs.command.outputs.commands }}
```

## Notes

- Existing behavior remains unchanged unless callers choose to write to `$GITHUB_OUTPUT`
- `commands` output is expected to be empty in most runs unless explicitly set in the `commands` step
- `commands` input name remains plural (`inputs.commands`)
