### PR TITLE
feat: improve commands failure diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,6 @@ The `commands` block runs in strict shell mode. A command failure (including opt
 - For optional matches, use guards like `grep ... || true`
 - Prefer explicit conditional checks when an empty result is valid
 - Set `verbose: true` to enable `set -x` tracing for the `commands` block and internal output processing
-- `debug_commands: true` remains supported as a backward-compatible alias (deprecated; prefer `verbose`)
 
 ## Safe Debugging
 

--- a/README.md
+++ b/README.md
@@ -164,11 +164,11 @@ The `commands` block runs in strict shell mode. A command failure (including opt
 
 - For optional matches, use guards like `grep ... || true`
 - Prefer explicit conditional checks when an empty result is valid
-- Set `verbose: true` to enable `set -x` tracing for the `commands` block and internal output processing
+- Set `verbose: true` to enable `set -x` tracing for the `commands` block and internal output processing; enable it temporarily and only when you are confident sensitive values will not be printed
 
 ## Safe Debugging
 
-When `verbose: true` is enabled, shell tracing may show expanded command arguments and environment usage in logs. Avoid printing sensitive values directly in commands.
+When `verbose: true` is enabled, shell tracing may show expanded command arguments, environment usage, and command output in logs. GitHub masks known secrets, but derived or partial secret values can still leak. Use this mode only for short-lived troubleshooting and avoid commands that print or interpolate sensitive values.
 
 # Feedback
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ The `commands` block runs in strict shell mode. A command failure (including opt
 
 - For optional matches, use guards like `grep ... || true`
 - Prefer explicit conditional checks when an empty result is valid
-- Set `verbose: true` to enable `set -x` tracing for the `commands` block
+- Set `verbose: true` to enable `set -x` tracing for the `commands` block and internal output processing
 - `debug_commands: true` remains supported as a backward-compatible alias
 
 # Feedback

--- a/README.md
+++ b/README.md
@@ -165,7 +165,11 @@ The `commands` block runs in strict shell mode. A command failure (including opt
 - For optional matches, use guards like `grep ... || true`
 - Prefer explicit conditional checks when an empty result is valid
 - Set `verbose: true` to enable `set -x` tracing for the `commands` block and internal output processing
-- `debug_commands: true` remains supported as a backward-compatible alias
+- `debug_commands: true` remains supported as a backward-compatible alias (deprecated; prefer `verbose`)
+
+## Safe Debugging
+
+When `verbose: true` is enabled, shell tracing may show expanded command arguments and environment usage in logs. Avoid printing sensitive values directly in commands.
 
 # Feedback
 

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ Provide as few as zero commands to login only.  There is a separate parameter fo
     # Timeout for command or cronjob; e.g. 10m
     timeout: 10m
 
-    # Debug commands with bash xtrace (set -x)
-    debug_commands: false
+    # Enable verbose command tracing with bash xtrace (set -x)
+    verbose: false
 ```
 
 # Example: Login only
@@ -164,7 +164,8 @@ The `commands` block runs in strict shell mode. A command failure (including opt
 
 - For optional matches, use guards like `grep ... || true`
 - Prefer explicit conditional checks when an empty result is valid
-- Set `debug_commands: true` to enable `set -x` tracing for the `commands` block
+- Set `verbose: true` to enable `set -x` tracing for the `commands` block
+- `debug_commands: true` remains supported as a backward-compatible alias
 
 # Feedback
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ Provide as few as zero commands to login only.  There is a separate parameter fo
 
     # Timeout for command or cronjob; e.g. 10m
     timeout: 10m
+
+    # Debug commands with bash xtrace (set -x)
+    debug_commands: false
 ```
 
 # Example: Login only
@@ -154,6 +157,14 @@ jobs:
           echo "Triggered = ${{ needs.command.outputs.triggered }}"
           echo "Command output = ${{ needs.command.outputs.commands }}"
 ```
+
+# Troubleshooting
+
+The `commands` block runs in strict shell mode. A command failure (including optional `grep` misses in pipelines) can stop the step immediately.
+
+- For optional matches, use guards like `grep ... || true`
+- Prefer explicit conditional checks when an empty result is valid
+- Set `debug_commands: true` to enable `set -x` tracing for the `commands` block
 
 # Feedback
 

--- a/action.yml
+++ b/action.yml
@@ -197,15 +197,12 @@ runs:
         fi
 
         if [ "$ENABLE_VERBOSE" = "true" ]; then
+          echo "::notice::Verbose mode enabled for commands step (includes internal output processing)."
           set -x
         fi
 
         # Run command(s)
         ${{ inputs.commands }}
-
-        if [ "$ENABLE_VERBOSE" = "true" ]; then
-          set +x
-        fi
 
         trap - ERR
 
@@ -238,6 +235,10 @@ runs:
             fi
             echo "$DELIM"
           } >> "$REAL_GITHUB_OUTPUT"
+        fi
+
+        if [ "$ENABLE_VERBOSE" = "true" ]; then
+          set +x
         fi
 
     - if: steps.diff.outputs.triggered == 'true' && inputs.commands && inputs.cronjob

--- a/action.yml
+++ b/action.yml
@@ -171,11 +171,21 @@ runs:
       shell: bash
       run: |
         set -eEuo pipefail
+        ACTION_SOURCE="bcgov/action-oc-runner"
 
         on_commands_error() {
           exit_code=$?
-          echo "::error title=commands input failed::commands block failed with exit code ${exit_code}."
-          echo "::error::If optional grep/pipeline failures are expected, guard them with '|| true' or explicit condition checks."
+          echo "::error title=${ACTION_SOURCE}: commands input failed::[${ACTION_SOURCE}] commands block failed with exit code ${exit_code}."
+          echo "::error::[${ACTION_SOURCE}] If optional grep/pipeline failures are expected, guard them with '|| true' or explicit condition checks."
+          if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+            {
+              echo "### ${ACTION_SOURCE} failure"
+              echo
+              echo "- Component: commands input"
+              echo "- Exit code: ${exit_code}"
+              echo "- Hint: if optional grep/pipeline failures are expected, guard with \`|| true\` or explicit condition checks"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
           exit "$exit_code"
         }
 
@@ -187,7 +197,7 @@ runs:
         ENABLE_VERBOSE="${{ inputs.verbose }}"
 
         if [ "$ENABLE_VERBOSE" = "true" ]; then
-          echo "::notice::Verbose mode enabled for commands step (includes internal output processing)."
+          echo "::notice::[${ACTION_SOURCE}] Verbose mode enabled for commands step (includes internal output processing)."
           set -x
         fi
 

--- a/action.yml
+++ b/action.yml
@@ -179,8 +179,6 @@ runs:
           exit "$exit_code"
         }
 
-        trap on_commands_error ERR
-
         REAL_GITHUB_OUTPUT="$GITHUB_OUTPUT"
         ACTION_OUTPUT_FILE="$(mktemp)"
         export GITHUB_OUTPUT="$ACTION_OUTPUT_FILE"
@@ -192,6 +190,8 @@ runs:
           echo "::notice::Verbose mode enabled for commands step (includes internal output processing)."
           set -x
         fi
+
+        trap on_commands_error ERR
 
         # Run command(s)
         ${{ inputs.commands }}

--- a/action.yml
+++ b/action.yml
@@ -84,11 +84,6 @@ inputs:
       Example: true, false
     default: "false"
     pattern: "^(true|false)$"
-  debug_commands:
-    description: |
-      Deprecated alias for `verbose`; kept for backward compatibility
-    default: "false"
-    pattern: "^(true|false)$"
 
 outputs:
   commands:
@@ -192,9 +187,6 @@ runs:
         trap 'rm -f "$ACTION_OUTPUT_FILE"' EXIT
 
         ENABLE_VERBOSE="${{ inputs.verbose }}"
-        if [ "$ENABLE_VERBOSE" != "true" ] && [ "${{ inputs.debug_commands }}" = "true" ]; then
-          ENABLE_VERBOSE="true"
-        fi
 
         if [ "$ENABLE_VERBOSE" = "true" ]; then
           echo "::notice::Verbose mode enabled for commands step (includes internal output processing)."

--- a/action.yml
+++ b/action.yml
@@ -78,6 +78,12 @@ inputs:
       Example: 10m, 30s, 1h
     default: 10m
     pattern: "^[0-9]+[mhs]$"
+  debug_commands:
+    description: |
+      Enable bash xtrace (`set -x`) for commands input debugging
+      Example: true, false
+    default: "false"
+    pattern: "^(true|false)$"
 
 outputs:
   commands:
@@ -164,10 +170,23 @@ runs:
       id: commands
       shell: bash
       run: |
+        on_commands_error() {
+          exit_code=$?
+          echo "::error title=commands input failed::commands block failed with exit code ${exit_code}."
+          echo "::error::If optional grep/pipeline failures are expected, guard them with '|| true' or explicit condition checks."
+          exit "$exit_code"
+        }
+
+        trap on_commands_error ERR
+
         REAL_GITHUB_OUTPUT="$GITHUB_OUTPUT"
         ACTION_OUTPUT_FILE="$(mktemp)"
         export GITHUB_OUTPUT="$ACTION_OUTPUT_FILE"
         trap 'rm -f "$ACTION_OUTPUT_FILE"' EXIT
+
+        if [ "${{ inputs.debug_commands }}" = "true" ]; then
+          set -x
+        fi
 
         # Run command(s)
         ${{ inputs.commands }}

--- a/action.yml
+++ b/action.yml
@@ -170,6 +170,8 @@ runs:
       id: commands
       shell: bash
       run: |
+        set -eEuo pipefail
+
         on_commands_error() {
           exit_code=$?
           echo "::error title=commands input failed::commands block failed with exit code ${exit_code}."
@@ -190,6 +192,12 @@ runs:
 
         # Run command(s)
         ${{ inputs.commands }}
+
+        if [ "${{ inputs.debug_commands }}" = "true" ]; then
+          set +x
+        fi
+
+        trap - ERR
 
         # Map user-written output lines to the action's generic commands output.
         # Allows plain `echo "value" >> "$GITHUB_OUTPUT"` without requiring `commands=`.

--- a/action.yml
+++ b/action.yml
@@ -175,6 +175,7 @@ runs:
 
         on_commands_error() {
           exit_code=$?
+          set +x
           echo "::error title=${ACTION_SOURCE}: commands input failed::[${ACTION_SOURCE}] commands block failed with exit code ${exit_code}."
           echo "::error::[${ACTION_SOURCE}] If optional grep/pipeline failures are expected, guard them with '|| true' or explicit condition checks."
           if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then

--- a/action.yml
+++ b/action.yml
@@ -78,10 +78,15 @@ inputs:
       Example: 10m, 30s, 1h
     default: 10m
     pattern: "^[0-9]+[mhs]$"
-  debug_commands:
+  verbose:
     description: |
       Enable bash xtrace (`set -x`) for commands input debugging
       Example: true, false
+    default: "false"
+    pattern: "^(true|false)$"
+  debug_commands:
+    description: |
+      Deprecated alias for `verbose`; kept for backward compatibility
     default: "false"
     pattern: "^(true|false)$"
 
@@ -186,14 +191,19 @@ runs:
         export GITHUB_OUTPUT="$ACTION_OUTPUT_FILE"
         trap 'rm -f "$ACTION_OUTPUT_FILE"' EXIT
 
-        if [ "${{ inputs.debug_commands }}" = "true" ]; then
+        ENABLE_VERBOSE="${{ inputs.verbose }}"
+        if [ "$ENABLE_VERBOSE" != "true" ] && [ "${{ inputs.debug_commands }}" = "true" ]; then
+          ENABLE_VERBOSE="true"
+        fi
+
+        if [ "$ENABLE_VERBOSE" = "true" ]; then
           set -x
         fi
 
         # Run command(s)
         ${{ inputs.commands }}
 
-        if [ "${{ inputs.debug_commands }}" = "true" ]; then
+        if [ "$ENABLE_VERBOSE" = "true" ]; then
           set +x
         fi
 


### PR DESCRIPTION
## Summary

Improves operator visibility when user-provided `commands` fail by adding explicit error annotations and optional command tracing controls.

## What Changed

- Added strict execution for command handling in `action.yml`:
  - `set -eEuo pipefail`
- Added scoped `ERR` trap around user `commands` execution to emit actionable failure annotations:
  - reports exit code
  - explains common optional grep/pipeline failure behavior
  - suggests `|| true` or explicit conditional guards
  - trap is cleared before internal output post-processing
- Added tracing input:
  - `verbose` (default `false`) to enable bash `set -x`
- Expanded verbose tracing scope to include command-step internals:
  - user-provided command execution
  - internal output mapping/post-processing in the commands step
- Updated `README.md`:
  - documents `verbose`
  - includes troubleshooting guidance for strict-shell command failures
  - includes safe debugging guidance

## Why

Downstream users experienced failures with low diagnostic clarity. This keeps fail-fast behavior while providing immediate, actionable guidance in logs and an opt-in tracing mode for troubleshooting.

## Validation

- Verified no file-level errors in updated `action.yml` and `README.md`
- Confirmed default behavior remains quiet/strict unless `verbose` is enabled

## Example

```yaml
- uses: bcgov/action-oc-runner@vX.Y.Z
  with:
    oc_namespace: ${{ vars.oc_namespace }}
    oc_server: ${{ vars.oc_server }}
    oc_token: ${{ secrets.OC_TOKEN }}
    verbose: true
    commands: |
      oc whoami
      grep "optional" missing.txt || true
```
