### PR TITLE
feat: support private repos

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -163,6 +163,7 @@ runs:
     - if: steps.diff.outputs.triggered == 'true'
       uses: actions/checkout@v6
       with:
+        token: ${{ github.token }}
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.ref }}
 
@@ -252,6 +253,8 @@ runs:
     - if: steps.diff.outputs.triggered == 'true' || github.repository != inputs.repository
       name: Checkout local repo to make sure action.yml is present
       uses: actions/checkout@v6
+      with:
+        token: ${{ github.token }}
 
     - if: steps.diff.outputs.triggered == 'true' && inputs.cronjob
       id: cronjob

--- a/action.yml
+++ b/action.yml
@@ -78,6 +78,9 @@ inputs:
       Example: 10m, 30s, 1h
     default: 10m
     pattern: "^[0-9]+[mhs]$"
+  token:
+    description: Specify token (GH or PAT), instead of inheriting one from the calling workflow
+    default: ${{ github.token }}
   verbose:
     description: |
       Enable bash xtrace (`set -x`) for commands input debugging
@@ -163,7 +166,7 @@ runs:
     - if: steps.diff.outputs.triggered == 'true'
       uses: actions/checkout@v6
       with:
-        token: ${{ github.token }}
+        token: ${{ inputs.token }}
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.ref }}
 
@@ -254,7 +257,7 @@ runs:
       name: Checkout local repo to make sure action.yml is present
       uses: actions/checkout@v6
       with:
-        token: ${{ github.token }}
+        token: ${{ inputs.token }}
 
     - if: steps.diff.outputs.triggered == 'true' && inputs.cronjob
       id: cronjob


### PR DESCRIPTION
## Summary

Add explicit `token: ${{ github.token }}` to both `actions/checkout@v6` steps in the composite action.

## Why

When `action-oc-runner` is called from a private repository (via a reusable workflow in another repo), the implicit `${{ github.token }}` may not properly resolve in the composite action context. Adding the explicit token parameter ensures checkout works reliably even in private-repo scenarios where the caller has granted `contents: read` permission.

This is part of fixing the broader issue where private-repo consumers of bcgov reusable workflows encounter checkout failures.

## Changes

- Line 165: Add `token: ${{ github.token }}` to checkout of caller repo
- Line 256: Add `token: ${{ github.token }}` to checkout of local repo

Relates to bcgov/quickstart-openshift-helpers#247