### PR TITLE
feat: cache oc cli binary to improve reliability

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ inputs:
       Override oc version, >= 4.0
       Example: 4.18
     default: "4.18"
-    pattern: '^4\.[0-9]+$'
+    pattern: '^(4\.[0-9]+|latest)$'
   repository:
     description: |
       Optionally, specify a different repo to clone
@@ -120,7 +120,7 @@ runs:
         ref: ${{ inputs.diff_branch }}
 
     - name: Cache OpenShift CLI
-      if: steps.diff.outputs.triggered == 'true'
+      if: steps.diff.outputs.triggered == 'true' && inputs.oc_version != 'latest'
       uses: actions/cache@v4
       with:
         path: /usr/local/bin/oc
@@ -128,7 +128,7 @@ runs:
 
     - if: steps.diff.outputs.triggered == 'true'
       env:
-        OC: ${{ format('stable-{0}', inputs.oc_version) }}
+        OC: ${{ inputs.oc_version == 'latest' && 'latest' || format('stable-{0}', inputs.oc_version) }}
       shell: bash
       working-directory: /usr/local/bin
       run: |

--- a/action.yml
+++ b/action.yml
@@ -120,11 +120,11 @@ runs:
         ref: ${{ inputs.diff_branch }}
 
     - name: Cache OpenShift CLI
-      if: steps.diff.outputs.triggered == 'true'
+      if: steps.diff.outputs.triggered == 'true' && inputs.oc_version != 'latest'
       uses: actions/cache@v4
       with:
         path: /usr/local/bin/oc
-        key: oc-cli-${{ inputs.oc_version == 'latest' && 'latest' || format('stable-{0}', inputs.oc_version) }}-${{ runner.os }}
+        key: oc-cli-stable-${{ inputs.oc_version }}-${{ runner.os }}-${{ runner.arch }}
 
     - if: steps.diff.outputs.triggered == 'true'
       env:

--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ inputs:
       Override oc version, >= 4.0
       Example: 4.18
     default: "4.18"
-    pattern: '^(4\.[0-9]+|latest)$'
+    pattern: '^4\.[0-9]+$'
   repository:
     description: |
       Optionally, specify a different repo to clone
@@ -120,7 +120,7 @@ runs:
         ref: ${{ inputs.diff_branch }}
 
     - name: Cache OpenShift CLI
-      if: steps.diff.outputs.triggered == 'true' && inputs.oc_version != 'latest'
+      if: steps.diff.outputs.triggered == 'true'
       uses: actions/cache@v4
       with:
         path: /usr/local/bin/oc
@@ -128,7 +128,7 @@ runs:
 
     - if: steps.diff.outputs.triggered == 'true'
       env:
-        OC: ${{ inputs.oc_version == 'latest' && 'latest' || format('stable-{0}', inputs.oc_version) }}
+        OC: ${{ format('stable-{0}', inputs.oc_version) }}
       shell: bash
       working-directory: /usr/local/bin
       run: |

--- a/action.yml
+++ b/action.yml
@@ -119,6 +119,13 @@ runs:
         triggers: ${{ inputs.triggers }}
         ref: ${{ inputs.diff_branch }}
 
+    - name: Cache OpenShift CLI
+      if: steps.diff.outputs.triggered == 'true'
+      uses: actions/cache@v4
+      with:
+        path: /usr/local/bin/oc
+        key: oc-cli-${{ inputs.oc_version == 'latest' && 'latest' || format('stable-{0}', inputs.oc_version) }}-${{ runner.os }}
+
     - if: steps.diff.outputs.triggered == 'true'
       env:
         OC: ${{ inputs.oc_version == 'latest' && 'latest' || format('stable-{0}', inputs.oc_version) }}


### PR DESCRIPTION
This PR adds a caching step for the `oc` binary using `actions/cache@v4`. This avoids repeatedly downloading from `mirror.openshift.com` on every run, mitigating connection timeouts and rate limits. The cache key includes the OS, architecture, and exact `oc` version to prevent `exec format error` on different runners.