### PR TITLE
feat!: completely remove support for 'latest' oc_version

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -98,7 +98,7 @@ jobs:
     needs: legacy
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7      
+      - uses: actions/checkout@v7
       - id: cronjob
         uses: ./
         with:
@@ -108,7 +108,6 @@ jobs:
           oc_namespace: ${{ vars.oc_namespace }}
           oc_server: ${{ vars.oc_server }}
           oc_token: ${{ secrets.oc_token }}
-
           timeout: 1m
           triggers: ('.github/' 'action.yml' 'cronjob/' 'scripts/run_cronjob.sh')
 

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -108,7 +108,7 @@ jobs:
           oc_namespace: ${{ vars.oc_namespace }}
           oc_server: ${{ vars.oc_server }}
           oc_token: ${{ secrets.oc_token }}
-          oc_version: latest
+
           timeout: 1m
           triggers: ('.github/' 'action.yml' 'cronjob/' 'scripts/run_cronjob.sh')
 

--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ inputs:
       Override oc version, >= 4.0
       Example: 4.18
     default: "4.18"
-    pattern: '^(4\.[0-9]+|latest)$'
+    pattern: '^4\.[0-9]+$'
   repository:
     description: |
       Optionally, specify a different repo to clone
@@ -128,7 +128,7 @@ runs:
 
     - if: steps.diff.outputs.triggered == 'true'
       env:
-        OC: ${{ inputs.oc_version == 'latest' && 'latest' || format('stable-{0}', inputs.oc_version) }}
+        OC: ${{ format('stable-{0}', inputs.oc_version) }}
       shell: bash
       working-directory: /usr/local/bin
       run: |

--- a/action.yml
+++ b/action.yml
@@ -155,7 +155,6 @@ runs:
           exit 1
         fi
 
-
         # Install CLI Tool and Login
         # Check if oc is already installed
         if ! command -v oc &>/dev/null; then

--- a/action.yml
+++ b/action.yml
@@ -156,7 +156,7 @@ runs:
         fi
         OC_VERSION_INPUT="${{ inputs.oc_version }}"
         if ! [[ "${OC_VERSION_INPUT}" =~ ^4\.[0-9]+$ ]]; then
-          echo "::error::Invalid oc_version: '${OC_VERSION_INPUT}'. Must be a stable 4.x version (e.g. 4.18). 'latest' is no longer supported."
+          echo "::error::Invalid oc_version: '${OC_VERSION_INPUT}'. Must be a stable 4.x version (e.g. 4.18)."
           exit 1
         fi
 

--- a/action.yml
+++ b/action.yml
@@ -154,6 +154,11 @@ runs:
           echo "::error::Invalid login_attempts: '${ATTEMPTS}'. Must be a positive integer."
           exit 1
         fi
+        OC_VERSION_INPUT="${{ inputs.oc_version }}"
+        if ! [[ "${OC_VERSION_INPUT}" =~ ^4\.[0-9]+$ ]]; then
+          echo "::error::Invalid oc_version: '${OC_VERSION_INPUT}'. Must be a stable 4.x version (e.g. 4.18). 'latest' is no longer supported."
+          exit 1
+        fi
 
         # Install CLI Tool and Login
         # Check if oc is already installed

--- a/action.yml
+++ b/action.yml
@@ -154,11 +154,7 @@ runs:
           echo "::error::Invalid login_attempts: '${ATTEMPTS}'. Must be a positive integer."
           exit 1
         fi
-        OC_VERSION_INPUT="${{ inputs.oc_version }}"
-        if ! [[ "${OC_VERSION_INPUT}" =~ ^4\.[0-9]+$ ]]; then
-          echo "::error::Invalid oc_version: '${OC_VERSION_INPUT}'. Must be a stable 4.x version (e.g. 4.18)."
-          exit 1
-        fi
+
 
         # Install CLI Tool and Login
         # Check if oc is already installed


### PR DESCRIPTION
This PR drops the ability to explicitly pass `oc_version: 'latest'`. We verified that `latest` was not currently in use across our repositories. Removing this option enforces that calling workflows use stable, cluster-compatible client versions (like the default of `4.18`), preventing incompatibilities that arise when the bleeding-edge CLI outpaces our OpenShift clusters.